### PR TITLE
[bugfix] default channels should be appended not prepended

### DIFF
--- a/tools/src/com/github/nh13/condaenvbuilder/api/CondaStep.scala
+++ b/tools/src/com/github/nh13/condaenvbuilder/api/CondaStep.scala
@@ -25,7 +25,7 @@ case class CondaStep(channels: Seq[Channel]=Seq.empty, requirements: Seq[Require
       channels     = (steps.flatMap(_.channels) ++ this.channels).distinct)
   }
 
-  /** Applies (in-order) channels and requirements from the given step(s).  The default channels are prepended to the
+  /** Applies (in-order) requirements from the given step(s).  The default channels are appended (in-order) to the
     * current list of channels.  Any requirement that has a default version is updated (and must be present in the
     * default step).
     *
@@ -34,12 +34,12 @@ case class CondaStep(channels: Seq[Channel]=Seq.empty, requirements: Seq[Require
     */
   def withDefaults(requirementsMap: Map[String, Requirement], channels: Seq[Channel]): CondaStep = {
     this.copy(
-      channels     = (channels ++ this.channels).distinct,
+      channels     = (this.channels ++ channels).distinct,
       requirements = Requirement.withDefaults(requirements=this.requirements, defaultsMap=requirementsMap)
     )
   }
 
-  /** Applies the default step to this step.  The default channels are prepended to the current list of channels.  Any
+  /** Applies the default step to this step.  The default channels are appended to the current list of channels.  Any
     * requirement that has a default version is updated (and must be present in the default step).
     *
     * @param defaults the default step.
@@ -47,7 +47,7 @@ case class CondaStep(channels: Seq[Channel]=Seq.empty, requirements: Seq[Require
   def withDefaults(defaults: Step): CondaStep = defaults match {
     case _defaults: CondaStep =>
       this.copy(
-        channels     = (_defaults.channels ++ this.channels).distinct,
+        channels     = (this.channels ++ _defaults.channels).distinct,
         requirements = Requirement.withDefaults(requirements=this.requirements, defaults=_defaults.requirements),
       )
     case _ => this

--- a/tools/test/src/com/github/nh13/condaenvbuilder/api/CondaStepTest.scala
+++ b/tools/test/src/com/github/nh13/condaenvbuilder/api/CondaStepTest.scala
@@ -80,12 +80,15 @@ class CondaStepTest extends UnitSpec {
     step.withDefaults(new DummyStep) shouldBe step
   }
 
-  it should "prepended default channels are to the current list of channels" in {
+  it should "append default channels are to the current list of channels" in {
     val step1 = CondaStep(channels=Seq("arg3", "arg4"))
     val step2 = CondaStep(channels=Seq("arg1", "arg2"))
+    val step3 = CondaStep(channels=Seq("arg4", "arg5"))
     step1.withDefaults(step1) shouldBe step1
-    step1.withDefaults(step2).channels should contain theSameElementsInOrderAs Seq("arg1", "arg2", "arg3", "arg4")
-    step2.withDefaults(step1).channels should contain theSameElementsInOrderAs Seq("arg3", "arg4", "arg1", "arg2")
+    step1.withDefaults(step2).channels should contain theSameElementsInOrderAs Seq("arg3", "arg4", "arg1", "arg2")
+    step2.withDefaults(step1).channels should contain theSameElementsInOrderAs Seq("arg1", "arg2", "arg3", "arg4")
+    step1.withDefaults(step3).channels should contain theSameElementsInOrderAs Seq("arg3", "arg4", "arg5")
+    step3.withDefaults(step1).channels should contain theSameElementsInOrderAs Seq("arg4", "arg5", "arg3")
   }
 
   it should "apply defaults to requirements with defaults" in {


### PR DESCRIPTION


Consider the input config:

```yaml
environments:
  defaults:
    steps:
      - conda:
          channels:
              - conda-forge
              - bioconda
              - defaults
  myenv:
    steps:
      - conda:
        channels:
          - r
          - conda-forge
          - bioconda
          - defaults
```

The previous implementation would _prepend_ the default channels.  So conda requirements yaml for `myenv` would be:

```yaml
name: myenv
channels:
          - conda-forge
          - bioconda
          - defaults                 
          - r
```   

The bugfix keeps the order from the environment, and _appends_ the default channels:

```yaml
name: myenv
channels:
          - r
          - conda-forge
          - bioconda
          - defaults
```         