### PR TITLE
[bug-fix] allow non-default child requirements to override inherited …

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,10 +474,10 @@ Below is the output from the example YAML
 
 ```
 group              name               value                       source
-alignment          hisat2             hisat2=2.2.0                conda
 alignment          hisat2             samtools=1.9                conda
-alignment          bwa                bwa=0.7.17                  conda
+alignment          hisat2             hisat2=2.2.0                conda
 alignment          bwa                samtools=1.9                conda
+alignment          bwa                bwa=0.7.17                  conda
 alignment          samtools           samtools=1.9                conda
 conda-env-builder  conda-env-builder  pybedtools=0.8.1            conda
 conda-env-builder  conda-env-builder  yaml=0.1.7                  conda

--- a/tools/src/com/github/nh13/condaenvbuilder/api/CondaStep.scala
+++ b/tools/src/com/github/nh13/condaenvbuilder/api/CondaStep.scala
@@ -21,8 +21,9 @@ case class CondaStep(channels: Seq[Channel]=Seq.empty, requirements: Seq[Require
   override def inheritFrom(step: Step*): CondaStep = {
     val steps = step.collect { case s: CondaStep => s }
     this.copy(
-      requirements = Requirement.join(parent=requirements, child=steps.flatMap(_.requirements)),
-      channels     = (steps.flatMap(_.channels) ++ this.channels).distinct)
+      requirements = Requirement.join(parent=steps.flatMap(_.requirements), child=requirements),
+      channels     = (steps.flatMap(_.channels) ++ this.channels).distinct
+    )
   }
 
   /** Applies (in-order) requirements from the given step(s).  The default channels are appended (in-order) to the

--- a/tools/src/com/github/nh13/condaenvbuilder/api/PipStep.scala
+++ b/tools/src/com/github/nh13/condaenvbuilder/api/PipStep.scala
@@ -21,7 +21,7 @@ case class PipStep(args: Seq[String]=Seq.empty, requirements: Seq[Requirement]=S
     // scope here.
     this.copy(
       args         = (args ++ steps.flatMap(_.args)).distinct,
-      requirements = Requirement.join(parent=requirements, child=steps.flatMap(_.requirements))
+      requirements = Requirement.join(parent=steps.flatMap(_.requirements), child=requirements)
     )
   }
 

--- a/tools/src/com/github/nh13/condaenvbuilder/api/Requirement.scala
+++ b/tools/src/com/github/nh13/condaenvbuilder/api/Requirement.scala
@@ -131,8 +131,8 @@ object Requirement extends LazyLogging {
     }
     val requirements = (parentsRemaining ++ childrenRemaining).distinct
 
-    // Developer note: consider at some in point in the future to do package version comparison.  For now, just throw
-    // an exception.
+    // Developer note: consider at some in point in the future to do package version comparison.  For now, just log
+    // a warning
     requirements.groupBy(_.name).iterator.filter(_._2.length > 1).foreach { case (name, pkgs) =>
       logger.warning(f"Found ${pkgs.length} package versions for '$name': " + pkgs.mkString(","))
     }

--- a/tools/src/com/github/nh13/condaenvbuilder/api/Spec.scala
+++ b/tools/src/com/github/nh13/condaenvbuilder/api/Spec.scala
@@ -150,9 +150,9 @@ object Spec {
     * @throws IllegalArgumentException if an environment that does not inherit cannot be found.
     */
   @tailrec
-  private def compile(specs: Seq[EnvironmentSpec],
-                      defaults: Seq[Step],
-                      environments: Seq[Environment]): Seq[Environment] = {
+  private[api] def compile(specs: Seq[EnvironmentSpec],
+                           defaults: Seq[Step],
+                           environments: Seq[Environment]): Seq[Environment] = {
     if (specs.isEmpty) environments else {
       specs.find(_.inherits.isEmpty) match {
         case None =>

--- a/tools/test/src/com/github/nh13/condaenvbuilder/api/CondaStepTest.scala
+++ b/tools/test/src/com/github/nh13/condaenvbuilder/api/CondaStepTest.scala
@@ -66,13 +66,15 @@ class CondaStepTest extends UnitSpec {
   }
 
   it should "inherit from a step with requirements" in {
-    val step    = CondaStep(requirements=Seq("a==1", "b==2").reqs)
+    val step    = CondaStep(requirements=Seq("a==5", "b==2").reqs)
     val parent1 = CondaStep(requirements=Seq("c==3", "d==4").reqs)
     val parent2 = CondaStep(requirements=Seq("a==1", "d==4").reqs)
 
     step.inheritFrom(step) shouldBe step
-    step.inheritFrom(parent1).requirements should contain theSameElementsInOrderAs Seq("a==1", "b==2", "c==3", "d==4").reqs
-    step.inheritFrom(parent2).requirements should contain theSameElementsInOrderAs Seq("a==1", "b==2", "d==4").reqs
+    // distinct requirements, so inherit them all!
+    step.inheritFrom(parent1).requirements should contain theSameElementsInOrderAs Seq("c==3", "d==4", "a==5", "b==2").reqs
+    // overlapping requirements, keep child
+    step.inheritFrom(parent2).requirements should contain theSameElementsInOrderAs Seq("d==4", "a==5", "b==2").reqs
   }
 
   "CondaStep.withDefaults" should "ignore non-conda steps" in {

--- a/tools/test/src/com/github/nh13/condaenvbuilder/api/PipStepTest.scala
+++ b/tools/test/src/com/github/nh13/condaenvbuilder/api/PipStepTest.scala
@@ -66,13 +66,15 @@ class PipStepTest extends UnitSpec {
   }
 
   it should "inherit from a step with requirements" in {
-    val step    = PipStep(requirements=Seq("a==1", "b==2").reqs)
+    val step    = PipStep(requirements=Seq("a==5", "b==2").reqs)
     val parent1 = PipStep(requirements=Seq("c==3", "d==4").reqs)
     val parent2 = PipStep(requirements=Seq("a==1", "d==4").reqs)
 
     step.inheritFrom(step) shouldBe step
-    step.inheritFrom(parent1).requirements should contain theSameElementsInOrderAs Seq("a==1", "b==2", "c==3", "d==4").reqs
-    step.inheritFrom(parent2).requirements should contain theSameElementsInOrderAs Seq("a==1", "b==2", "d==4").reqs
+    // distinct requirements, so inherit them all!
+    step.inheritFrom(parent1).requirements should contain theSameElementsInOrderAs Seq("c==3", "d==4", "a==5", "b==2").reqs
+    // overlapping requirements, keep child
+    step.inheritFrom(parent2).requirements should contain theSameElementsInOrderAs Seq("d==4", "a==5", "b==2").reqs
   }
 
   "PipStep.withDefaults" should "ignore non-pip steps" in {

--- a/tools/test/src/com/github/nh13/condaenvbuilder/api/RequirementTest.scala
+++ b/tools/test/src/com/github/nh13/condaenvbuilder/api/RequirementTest.scala
@@ -86,8 +86,15 @@ class RequirementTest extends UnitSpec {
     ) should contain theSameElementsInOrderAs Seq(Requirement("foo=1"))
   }
 
-  it should "log at debug level if there are two requirements for the same package" in {
-    Logger.level = LogLevel.Debug
+  it should "override parent requirements with a non-default child requirement with the same name" in {
+    Requirement.join(
+      parent = Seq(Requirement("foo=1")),
+      child  = Seq(Requirement("foo=2"))
+    ) should contain theSameElementsInOrderAs Seq(Requirement("foo=2"))
+  }
+
+  it should "log at warning level if there are two requirements for the same package" in {
+    Logger.level = LogLevel.Warning
     val logging: LoggerString = captureLogger { () =>
       Requirement.join(
         parent = Seq(Requirement("foo=1")),
@@ -95,7 +102,7 @@ class RequirementTest extends UnitSpec {
       )
     }
     Logger.level = LogLevel.Info
-    logging should include ("Found 2 package versions for 'foo'")
+    logging should include ("Overriding parent requirement foo=1 with child requirement foo=2")
   }
 
   "Requirement.encoder" should "return an encoder" in {

--- a/tools/test/src/com/github/nh13/condaenvbuilder/api/RequirementTest.scala
+++ b/tools/test/src/com/github/nh13/condaenvbuilder/api/RequirementTest.scala
@@ -105,6 +105,14 @@ class RequirementTest extends UnitSpec {
     logging should include ("Overriding parent requirement foo=1 with child requirement foo=2")
   }
 
+  it should "inherit the parent requirement when the child has a default requirement" in {
+    Requirement.join(
+      parent = Seq(Requirement("foo=1")),
+      child  = Seq(Requirement("foo")) // non-default
+    ) should contain theSameElementsInOrderAs Seq(Requirement("foo=1"))
+  }
+
+
   "Requirement.encoder" should "return an encoder" in {
     implicit val encoder: Encoder[Requirement] = Requirement.encoder
     Requirement("foo").asJson.toString shouldBe """"foo==default""""

--- a/tools/test/src/com/github/nh13/condaenvbuilder/api/SpecTest.scala
+++ b/tools/test/src/com/github/nh13/condaenvbuilder/api/SpecTest.scala
@@ -1,0 +1,41 @@
+package com.github.nh13.condaenvbuilder.api
+
+import com.github.nh13.condaenvbuilder.testing.UnitSpec
+import org.scalatest.OptionValues
+
+class SpecTest extends UnitSpec with OptionValues {
+
+  "Spec" should "only apply defaults if no package was specified in the case of inheritance" in {
+    // Defaults has a default version for foo, parent does not, and child has a different version than the default.
+    // So when compiled, parent should have version 1.1 and child 1.2 for foo.
+
+    val defaults = Seq(CondaStep(requirements=Seq("foo=1.1").reqs))
+
+    val parent   = EnvironmentSpec(environment=Environment(
+      name  = "parent",
+      steps = Seq(CondaStep(requirements=Seq("foo").reqs)),
+      group = ""
+    ))
+
+    val child   = EnvironmentSpec(inherits=Seq("parent"), environment=Environment(
+      name  = "child",
+      steps = Seq(CondaStep(requirements=Seq("foo=1.2").reqs)),
+      group = ""
+    ))
+
+    val environments = Spec.compile(
+      specs        = Seq(parent, child),
+      defaults     = defaults,
+      environments = Seq.empty
+    )
+
+    val compiledParent = environments.find(_.name == "parent").value
+
+    // Compiled parent should  have the default
+    compiledParent.steps should contain theSameElementsInOrderAs Seq(CondaStep(requirements=Seq("foo=1.1").reqs))
+
+    // Compiled child should not have the default, which has been applied to the parent, applied to itself
+    val compiledChild = environments.find(_.name == "child").value
+    compiledChild.steps should contain theSameElementsInOrderAs Seq(CondaStep(requirements=Seq("foo=1.2").reqs))
+  }
+}

--- a/tools/test/src/com/github/nh13/condaenvbuilder/tools/ToolsTest.scala
+++ b/tools/test/src/com/github/nh13/condaenvbuilder/tools/ToolsTest.scala
@@ -100,8 +100,8 @@ class ToolsTest extends UnitSpec {
       |        - conda-forge
       |        - bioconda
       |        requirements:
-      |        - hisat2=2.2.0
       |        - samtools=1.9
+      |        - hisat2=2.2.0
       |  bwa:
       |    group: alignment
       |    steps:
@@ -110,8 +110,8 @@ class ToolsTest extends UnitSpec {
       |        - conda-forge
       |        - bioconda
       |        requirements:
-      |        - bwa=0.7.17
       |        - samtools=1.9
+      |        - bwa=0.7.17
       |  samtools:
       |    group: alignment
       |    steps:
@@ -125,10 +125,10 @@ class ToolsTest extends UnitSpec {
 
   val tabulatedString: String = {
     """group	name	value	source
-      |alignment	hisat2	hisat2=2.2.0	conda
       |alignment	hisat2	samtools=1.9	conda
-      |alignment	bwa	bwa=0.7.17	conda
+      |alignment	hisat2	hisat2=2.2.0	conda
       |alignment	bwa	samtools=1.9	conda
+      |alignment	bwa	bwa=0.7.17	conda
       |alignment	samtools	samtools=1.9	conda
       |conda-env-builder	conda-env-builder	pybedtools=0.8.1	conda
       |conda-env-builder	conda-env-builder	yaml=0.1.7	conda
@@ -159,8 +159,8 @@ class ToolsTest extends UnitSpec {
       |        - conda-forge
       |        - bioconda
       |        requirements:
-      |        - bwa=0.7.17
       |        - samtools=1.9
+      |        - bwa=0.7.17
       |  hisat2:
       |    group: alignment
       |    steps:
@@ -169,8 +169,8 @@ class ToolsTest extends UnitSpec {
       |        - conda-forge
       |        - bioconda
       |        requirements:
-      |        - hisat2=2.2.0
       |        - samtools=1.9
+      |        - hisat2=2.2.0
       |  conda-env-builder:
       |    group: conda-env-builder
       |    steps:
@@ -215,8 +215,8 @@ class ToolsTest extends UnitSpec {
       |        - conda-forge
       |        - bioconda
       |        requirements:
-      |        - bwa=0.7.17
       |        - samtools=1.9
+      |        - bwa=0.7.17
       |  hisat2:
       |    group: alignment
       |    steps:
@@ -225,8 +225,8 @@ class ToolsTest extends UnitSpec {
       |        - conda-forge
       |        - bioconda
       |        requirements:
-      |        - hisat2=2.2.0
       |        - samtools=1.9
+      |        - hisat2=2.2.0
       |  conda-env-builder:
       |    group: conda-env-builder
       |    steps:
@@ -440,8 +440,8 @@ class ToolsTest extends UnitSpec {
           |  - conda-forge
           |  - bioconda
           |dependencies:
-          |  - bwa=0.7.17
-          |  - samtools=1.9""".stripMargin
+          |  - samtools=1.9
+          |  - bwa=0.7.17""".stripMargin
       }
       Io.readLines(bwaCondaPath).mkString("\n") shouldBe {
         """#/bin/bash


### PR DESCRIPTION
…requirements.

This change allows non-default child requirements override parent requirements
for requirements with the same name. Previously, both the parent and
child requirement would be produced, which causes issues during
downstream conda or pip package resolution.

A few other minor changes:
- change the API docs to for Requirements.join to say a warning log
message is produced, where previously it said incorrectly an exception
would be thrown, when there were two requirements with the sane name
- due to the bug fix above, the order of some of the dependencies may
change, for example in the output of Assemble or Tabulate.
- added a test for Spec.compile to verify that default requirements are
applied to a parent environment before a child tries to inherit from it,
and that a child requirement can override the parent requirement for a
requirement with the same name.

Example:
```yaml
name: 'name'
environments:
  defaults:
    steps:
      - conda:
          requirements:
            - foo=1
  parent:
    steps:
      - conda:
          requirements:
            - foo
  child:
    inherits:
      - parent
    steps:
      - conda:
          requirements:
            - foo=2
```

Previously, both `foo=1` (from the parent who uses the default version) and `foo=2` would be present in the `child.yml` conda environments file.  In the fix, the child _overrides_ the version for `foo`, so only `foo=2` is present.

