### PR TITLE
[feat] support conda platforms

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -21,7 +21,6 @@ private val fgSoptVersion             = "1.1.0-e565813-SNAPSHOT"
 private val circeYamlVersion          = "0.13.0"
 private val circeGenericVersion       = "0.13.0"
 private val circeGenericExtrasVersion = "0.13.0"
-private val enumeratumVersion         = "1.7.2"
 
 /** The ScalaTest settings. */
 trait ScalaTest extends TestModule {
@@ -143,7 +142,6 @@ object tools extends CommonModule {
     ivy"io.circe::circe-yaml::$circeYamlVersion",
     ivy"io.circe::circe-generic::$circeGenericVersion",
     ivy"io.circe::circe-generic-extras::$circeGenericExtrasVersion",
-    ivy"com.beachape::enumeratum::$enumeratumVersion",
     ivy"org.slf4j:slf4j-nop:1.7.6"  // For logging silence: https://www.slf4j.org/codes.html#StaticLoggerBinder
   )
 

--- a/build.sc
+++ b/build.sc
@@ -21,6 +21,7 @@ private val fgSoptVersion             = "1.1.0-e565813-SNAPSHOT"
 private val circeYamlVersion          = "0.13.0"
 private val circeGenericVersion       = "0.13.0"
 private val circeGenericExtrasVersion = "0.13.0"
+private val enumeratumVersion         = "1.7.2"
 
 /** The ScalaTest settings. */
 trait ScalaTest extends TestModule {
@@ -142,6 +143,7 @@ object tools extends CommonModule {
     ivy"io.circe::circe-yaml::$circeYamlVersion",
     ivy"io.circe::circe-generic::$circeGenericVersion",
     ivy"io.circe::circe-generic-extras::$circeGenericExtrasVersion",
+    ivy"com.beachape::enumeratum::$enumeratumVersion",
     ivy"org.slf4j:slf4j-nop:1.7.6"  // For logging silence: https://www.slf4j.org/codes.html#StaticLoggerBinder
   )
 

--- a/tools/src/com/github/condaincubator/condaenvbuilder/api/Platform.scala
+++ b/tools/src/com/github/condaincubator/condaenvbuilder/api/Platform.scala
@@ -1,0 +1,6 @@
+package com.github.condaincubator.condaenvbuilder.api
+
+/** The name of the platform (e.g. linux-32, linux-armv7l, win-64, osx-arm64) */
+object Platform {
+  type Platform = String
+}

--- a/tools/test/src/com/github/condaincubator/condaenvbuilder/api/CondaStepTest.scala
+++ b/tools/test/src/com/github/condaincubator/condaenvbuilder/api/CondaStepTest.scala
@@ -15,19 +15,22 @@ object CondaStepTest extends UnitSpec {
         |  ]
         |}""".stripMargin
     }),
-    // one channel, one requirement
-    (api.CondaStep(channels=Seq("some channel"), requirements=Seq("a==1").reqs), {
+    // one channel, one requirement, one platform
+    (api.CondaStep(channels=Seq("some channel"), requirements=Seq("a==1").reqs, platforms=Seq("linux-32")), {
       """{
         |  "channels" : [
         |    "some channel"
         |  ],
         |  "requirements" : [
         |    "a==1"
+        |  ],
+        |  "platforms" : [
+        |    "linux-32"
         |  ]
         |}""".stripMargin
     }),
-    // multiple channels and requirements
-    (api.CondaStep(channels=Seq("channel 1", "channel 2"), requirements=Seq("a==1", "b==2").reqs), {
+    // multiple channels, requirements, and platforms
+    (api.CondaStep(channels=Seq("channel 1", "channel 2"), requirements=Seq("a==1", "b==2").reqs, platforms=Seq("linux-32", "win-32")), {
       """{
         |  "channels" : [
         |    "channel 1",
@@ -36,11 +39,15 @@ object CondaStepTest extends UnitSpec {
         |  "requirements" : [
         |    "a==1",
         |    "b==2"
+        |  ],
+        |  "platforms" : [
+        |    "linux-32",
+        |    "win-32"
         |  ]
         |}""".stripMargin
     }),
     // empty requirements, empty channels
-    (CondaStep(channels=Seq.empty, requirements=Seq.empty), {
+    (CondaStep(channels=Seq.empty, requirements=Seq.empty, platforms=Seq.empty), {
       """{
         |  "channels" : [
         |  ],

--- a/tools/test/src/com/github/condaincubator/condaenvbuilder/tools/ToolsTest.scala
+++ b/tools/test/src/com/github/condaincubator/condaenvbuilder/tools/ToolsTest.scala
@@ -24,6 +24,8 @@ class ToolsTest extends UnitSpec {
       |            - python=3.6.10
       |            - samtools=1.10
       |            - yaml=0.1.7
+      |          platforms:
+      |            - linux-32
       |      - pip:
       |          requirements:
       |            - defopt==5.1.0
@@ -81,6 +83,8 @@ class ToolsTest extends UnitSpec {
       |        requirements:
       |        - pybedtools=0.8.1
       |        - yaml=0.1.7
+      |        platforms:
+      |        - linux-32
       |    - pip:
       |        args: []
       |        requirements:
@@ -101,6 +105,8 @@ class ToolsTest extends UnitSpec {
       |        requirements:
       |        - samtools=1.9
       |        - hisat2=2.2.0
+      |        platforms:
+      |        - linux-32
       |  bwa:
       |    group: alignment
       |    steps:
@@ -111,6 +117,8 @@ class ToolsTest extends UnitSpec {
       |        requirements:
       |        - samtools=1.9
       |        - bwa=0.7.17
+      |        platforms:
+      |        - linux-32
       |  samtools:
       |    group: alignment
       |    steps:
@@ -119,7 +127,9 @@ class ToolsTest extends UnitSpec {
       |        - conda-forge
       |        - bioconda
       |        requirements:
-      |        - samtools=1.9""".stripMargin
+      |        - samtools=1.9
+      |        platforms:
+      |        - linux-32""".stripMargin
   }
 
   val tabulatedString: String = {
@@ -150,6 +160,8 @@ class ToolsTest extends UnitSpec {
       |        - bioconda
       |        requirements:
       |        - samtools=1.9
+      |        platforms:
+      |        - linux-32
       |  bwa:
       |    group: alignment
       |    steps:
@@ -160,6 +172,8 @@ class ToolsTest extends UnitSpec {
       |        requirements:
       |        - samtools=1.9
       |        - bwa=0.7.17
+      |        platforms:
+      |        - linux-32
       |  hisat2:
       |    group: alignment
       |    steps:
@@ -170,6 +184,8 @@ class ToolsTest extends UnitSpec {
       |        requirements:
       |        - samtools=1.9
       |        - hisat2=2.2.0
+      |        platforms:
+      |        - linux-32
       |  conda-env-builder:
       |    group: conda-env-builder
       |    steps:
@@ -181,6 +197,8 @@ class ToolsTest extends UnitSpec {
       |        - pybedtools=0.8.1
       |        - yaml=0.1.7
       |        - pip==default
+      |        platforms:
+      |        - linux-32
       |    - pip:
       |        args: []
       |        requirements:
@@ -206,6 +224,8 @@ class ToolsTest extends UnitSpec {
       |        - bioconda
       |        requirements:
       |        - samtools=1.9
+      |        platforms:
+      |        - linux-32
       |  bwa:
       |    group: alignment
       |    steps:
@@ -216,6 +236,8 @@ class ToolsTest extends UnitSpec {
       |        requirements:
       |        - samtools=1.9
       |        - bwa=0.7.17
+      |        platforms:
+      |        - linux-32
       |  hisat2:
       |    group: alignment
       |    steps:
@@ -226,6 +248,8 @@ class ToolsTest extends UnitSpec {
       |        requirements:
       |        - samtools=1.9
       |        - hisat2=2.2.0
+      |        platforms:
+      |        - linux-32
       |  conda-env-builder:
       |    group: conda-env-builder
       |    steps:
@@ -236,6 +260,8 @@ class ToolsTest extends UnitSpec {
       |        requirements:
       |        - pybedtools=0.8.1
       |        - yaml=0.1.7
+      |        platforms:
+      |        - linux-32
       |    - pip:
       |        args: []
       |        requirements:


### PR DESCRIPTION
Support specifying conda platforms (e.g. from conda-lock):

 For example
```
   - conda:
     channels:
       - conda-forge
       - bioconda
     requirements:
       - samtools
       - fgbio=1.1.0
     platforms:
       - linux-32
       - osx-arm64
       - win32
```

Implements #30.