### PR TITLE
[fix] add platforms as-is to the output of Assemble and Solve

### DIFF
--- a/tools/src/com/github/condaincubator/condaenvbuilder/api/Platform.scala
+++ b/tools/src/com/github/condaincubator/condaenvbuilder/api/Platform.scala
@@ -1,6 +1,0 @@
-package com.github.condaincubator.condaenvbuilder.api
-
-/** The name of the platform (e.g. linux-32, linux-armv7l, win-64, osx-arm64) */
-object Platform {
-  type Platform = String
-}

--- a/tools/src/com/github/condaincubator/condaenvbuilder/io/BuildWriter.scala
+++ b/tools/src/com/github/condaincubator/condaenvbuilder/io/BuildWriter.scala
@@ -1,15 +1,15 @@
 package com.github.condaincubator.condaenvbuilder.io
 
-import java.io.PrintWriter
-import java.nio.file.Paths
 import com.fulcrumgenomics.commons.CommonsDef.{DirPath, FilePath}
 import com.fulcrumgenomics.commons.io.Io
 import com.fulcrumgenomics.commons.util.{LazyLogging, Logger}
-import com.github.condaincubator.condaenvbuilder.cmdline.CondaEnvironmentBuilderTool
 import com.github.condaincubator.condaenvbuilder.CondaEnvironmentBuilderDef.PathToYaml
 import com.github.condaincubator.condaenvbuilder.api.CodeStep.Command
 import com.github.condaincubator.condaenvbuilder.api.{CodeStep, CondaStep, Environment, PipStep}
-import com.github.condaincubator.condaenvbuilder.api.CondaStep
+import com.github.condaincubator.condaenvbuilder.cmdline.CondaEnvironmentBuilderTool
+
+import java.io.PrintWriter
+import java.nio.file.Paths
 
 /** Companion to [[BuildWriter]].  */
 object BuildWriter {
@@ -111,6 +111,12 @@ case class BuildWriter(environment: Environment,
 
     val writer = new PrintWriter(Io.toWriter(environmentYaml))
     writer.println(f"name: ${environment.name}")
+    condaStep.foreach { step =>
+      if (step.platforms.nonEmpty) {
+        writer.println("platforms:")
+        step.platforms.foreach { platform => writer.println(f"  - $platform") }
+      }
+    }
     condaStep.foreach { step =>
       if (step.channels.nonEmpty) {
         writer.println("channels:")

--- a/tools/src/com/github/condaincubator/condaenvbuilder/tools/Assemble.scala
+++ b/tools/src/com/github/condaincubator/condaenvbuilder/tools/Assemble.scala
@@ -1,16 +1,14 @@
 package com.github.condaincubator.condaenvbuilder.tools
 
-import java.nio.file.Files
 import com.fulcrumgenomics.commons.CommonsDef.DirPath
 import com.fulcrumgenomics.commons.io.Io
 import com.fulcrumgenomics.sopt.{arg, clp}
+import com.github.condaincubator.condaenvbuilder.CondaEnvironmentBuilderDef._
 import com.github.condaincubator.condaenvbuilder.api.{Environment, Spec}
 import com.github.condaincubator.condaenvbuilder.cmdline.{ClpGroups, CondaEnvironmentBuilderTool}
-import com.github.condaincubator.condaenvbuilder.CondaEnvironmentBuilderDef._
 import com.github.condaincubator.condaenvbuilder.io.{BuildWriter, SpecParser}
-import com.github.condaincubator.condaenvbuilder.api.Spec
-import com.github.condaincubator.condaenvbuilder.cmdline.CondaEnvironmentBuilderTool
-import com.github.condaincubator.condaenvbuilder.io.BuildWriter
+
+import java.nio.file.Files
 
 
 @clp(description =

--- a/tools/test/src/com/github/condaincubator/condaenvbuilder/api/CondaStepTest.scala
+++ b/tools/test/src/com/github/condaincubator/condaenvbuilder/api/CondaStepTest.scala
@@ -18,20 +18,24 @@ object CondaStepTest extends UnitSpec {
     // one channel, one requirement, one platform
     (api.CondaStep(channels=Seq("some channel"), requirements=Seq("a==1").reqs, platforms=Seq("linux-32")), {
       """{
+        |  "platforms" : [
+        |    "linux-32"
+        |  ],
         |  "channels" : [
         |    "some channel"
         |  ],
         |  "requirements" : [
         |    "a==1"
-        |  ],
-        |  "platforms" : [
-        |    "linux-32"
         |  ]
         |}""".stripMargin
     }),
     // multiple channels, requirements, and platforms
     (api.CondaStep(channels=Seq("channel 1", "channel 2"), requirements=Seq("a==1", "b==2").reqs, platforms=Seq("linux-32", "win-32")), {
       """{
+        |  "platforms" : [
+        |    "linux-32",
+        |    "win-32"
+        |  ],
         |  "channels" : [
         |    "channel 1",
         |    "channel 2"
@@ -39,10 +43,6 @@ object CondaStepTest extends UnitSpec {
         |  "requirements" : [
         |    "a==1",
         |    "b==2"
-        |  ],
-        |  "platforms" : [
-        |    "linux-32",
-        |    "win-32"
         |  ]
         |}""".stripMargin
     }),

--- a/tools/test/src/com/github/condaincubator/condaenvbuilder/tools/ToolsTest.scala
+++ b/tools/test/src/com/github/condaincubator/condaenvbuilder/tools/ToolsTest.scala
@@ -14,6 +14,8 @@ class ToolsTest extends UnitSpec {
       |  defaults:
       |    steps:
       |      - conda:
+      |          platforms:
+      |            - linux-32
       |          channels:
       |            - conda-forge
       |            - bioconda
@@ -24,8 +26,6 @@ class ToolsTest extends UnitSpec {
       |            - python=3.6.10
       |            - samtools=1.10
       |            - yaml=0.1.7
-      |          platforms:
-      |            - linux-32
       |      - pip:
       |          requirements:
       |            - defopt==5.1.0
@@ -77,14 +77,14 @@ class ToolsTest extends UnitSpec {
       |    group: conda-env-builder
       |    steps:
       |    - conda:
+      |        platforms:
+      |        - linux-32
       |        channels:
       |        - conda-forge
       |        - bioconda
       |        requirements:
       |        - pybedtools=0.8.1
       |        - yaml=0.1.7
-      |        platforms:
-      |        - linux-32
       |    - pip:
       |        args: []
       |        requirements:
@@ -99,37 +99,37 @@ class ToolsTest extends UnitSpec {
       |    group: alignment
       |    steps:
       |    - conda:
+      |        platforms:
+      |        - linux-32
       |        channels:
       |        - conda-forge
       |        - bioconda
       |        requirements:
       |        - samtools=1.9
       |        - hisat2=2.2.0
-      |        platforms:
-      |        - linux-32
       |  bwa:
       |    group: alignment
       |    steps:
       |    - conda:
+      |        platforms:
+      |        - linux-32
       |        channels:
       |        - conda-forge
       |        - bioconda
       |        requirements:
       |        - samtools=1.9
       |        - bwa=0.7.17
-      |        platforms:
-      |        - linux-32
       |  samtools:
       |    group: alignment
       |    steps:
       |    - conda:
+      |        platforms:
+      |        - linux-32
       |        channels:
       |        - conda-forge
       |        - bioconda
       |        requirements:
-      |        - samtools=1.9
-      |        platforms:
-      |        - linux-32""".stripMargin
+      |        - samtools=1.9""".stripMargin
   }
 
   val tabulatedString: String = {
@@ -155,41 +155,43 @@ class ToolsTest extends UnitSpec {
       |    group: alignment
       |    steps:
       |    - conda:
+      |        platforms:
+      |        - linux-32
       |        channels:
       |        - conda-forge
       |        - bioconda
       |        requirements:
       |        - samtools=1.9
-      |        platforms:
-      |        - linux-32
       |  bwa:
       |    group: alignment
       |    steps:
       |    - conda:
+      |        platforms:
+      |        - linux-32
       |        channels:
       |        - conda-forge
       |        - bioconda
       |        requirements:
       |        - samtools=1.9
       |        - bwa=0.7.17
-      |        platforms:
-      |        - linux-32
       |  hisat2:
       |    group: alignment
       |    steps:
       |    - conda:
+      |        platforms:
+      |        - linux-32
       |        channels:
       |        - conda-forge
       |        - bioconda
       |        requirements:
       |        - samtools=1.9
       |        - hisat2=2.2.0
-      |        platforms:
-      |        - linux-32
       |  conda-env-builder:
       |    group: conda-env-builder
       |    steps:
       |    - conda:
+      |        platforms:
+      |        - linux-32
       |        channels:
       |        - conda-forge
       |        - bioconda
@@ -197,8 +199,6 @@ class ToolsTest extends UnitSpec {
       |        - pybedtools=0.8.1
       |        - yaml=0.1.7
       |        - pip==default
-      |        platforms:
-      |        - linux-32
       |    - pip:
       |        args: []
       |        requirements:
@@ -219,49 +219,49 @@ class ToolsTest extends UnitSpec {
       |    group: alignment
       |    steps:
       |    - conda:
+      |        platforms:
+      |        - linux-32
       |        channels:
       |        - conda-forge
       |        - bioconda
       |        requirements:
       |        - samtools=1.9
-      |        platforms:
-      |        - linux-32
       |  bwa:
       |    group: alignment
       |    steps:
       |    - conda:
+      |        platforms:
+      |        - linux-32
       |        channels:
       |        - conda-forge
       |        - bioconda
       |        requirements:
       |        - samtools=1.9
       |        - bwa=0.7.17
-      |        platforms:
-      |        - linux-32
       |  hisat2:
       |    group: alignment
       |    steps:
       |    - conda:
+      |        platforms:
+      |        - linux-32
       |        channels:
       |        - conda-forge
       |        - bioconda
       |        requirements:
       |        - samtools=1.9
       |        - hisat2=2.2.0
-      |        platforms:
-      |        - linux-32
       |  conda-env-builder:
       |    group: conda-env-builder
       |    steps:
       |    - conda:
+      |        platforms:
+      |        - linux-32
       |        channels:
       |        - conda-forge
       |        - bioconda
       |        requirements:
       |        - pybedtools=0.8.1
       |        - yaml=0.1.7
-      |        platforms:
-      |        - linux-32
       |    - pip:
       |        args: []
       |        requirements:
@@ -461,6 +461,8 @@ class ToolsTest extends UnitSpec {
 
       Io.readLines(bwaYamlPath).mkString("\n") shouldBe {
             """name: bwa
+          |platforms:
+          |  - linux-32
           |channels:
           |  - conda-forge
           |  - bioconda


### PR DESCRIPTION
Note: this does not actually use the platform in the `Assemble` or `Solve` build files!  See #21 